### PR TITLE
Update CRD v1 docs

### DIFF
--- a/content/en/docs/concepts/extend-kubernetes/api-extension/custom-resources.md
+++ b/content/en/docs/concepts/extend-kubernetes/api-extension/custom-resources.md
@@ -183,7 +183,7 @@ Aggregated APIs offer more advanced API features and customization of other feat
 | Other Subresources | Add operations other than CRUD, such as "logs" or "exec". | No | Yes |
 | strategic-merge-patch | The new endpoints support PATCH with `Content-Type: application/strategic-merge-patch+json`. Useful for updating objects that may be modified both locally, and by the server. For more information, see ["Update API Objects in Place Using kubectl patch"](/docs/tasks/run-application/update-api-object-kubectl-patch/) | No | Yes |
 | Protocol Buffers | The new resource supports clients that want to use Protocol Buffers | No | Yes |
-| OpenAPI Schema | Is there an OpenAPI (swagger) schema for the types that can be dynamically fetched from the server? Is the user protected from misspelling field names by ensuring only allowed fields are set? Are types enforced (in other words, don't put an `int` in a `string` field?) | Yes, based on the [OpenAPI v3.0 validation](/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/#validation) schema (beta in 1.15) | Yes |
+| OpenAPI Schema | Is there an OpenAPI (swagger) schema for the types that can be dynamically fetched from the server? Is the user protected from misspelling field names by ensuring only allowed fields are set? Are types enforced (in other words, don't put an `int` in a `string` field?) | Yes, based on the [OpenAPI v3.0 validation](/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/#validation) schema (GA in 1.16) | Yes |
 
 ### Common Features
 

--- a/content/en/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions.md
+++ b/content/en/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions.md
@@ -86,6 +86,7 @@ spec:
 {{% /tab %}}
 {{% tab name="apiextensions.k8s.io/v1beta1" %}}
 ```yaml
+# Deprecated in v1.16 in favor of apiextensions.k8s.io/v1
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -678,6 +679,7 @@ spec:
 {{% /tab %}}
 {{% tab name="apiextensions.k8s.io/v1beta1" %}}
 ```yaml
+# Deprecated in v1.16 in favor of apiextensions.k8s.io/v1
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -915,22 +917,36 @@ columns.
         - name: v1
           served: true
           storage: true
+          schema:
+            openAPIV3Schema:
+              type: object
+              properties:
+                spec:
+                  type: object
+                  properties:
+                    cronSpec:
+                      type: string
+                    image:
+                      type: string
+                    replicas:
+                      type: integer
           additionalPrinterColumns:
           - name: Spec
             type: string
             description: The cron spec defining the interval a CronJob is run
-            JSONPath: .spec.cronSpec
+            jsonPath: .spec.cronSpec
           - name: Replicas
             type: integer
             description: The number of jobs launched by the CronJob
-            JSONPath: .spec.replicas
+            jsonPath: .spec.replicas
           - name: Age
             type: date
-            JSONPath: .metadata.creationTimestamp
+            jsonPath: .metadata.creationTimestamp
       ```
       {{% /tab %}}
       {{% tab name="apiextensions.k8s.io/v1beta1" %}}
       ```yaml
+      # Deprecated in v1.16 in favor of apiextensions.k8s.io/v1
       apiVersion: apiextensions.k8s.io/v1beta1
       kind: CustomResourceDefinition
       metadata:
@@ -945,6 +961,19 @@ columns.
           kind: CronTab
           shortNames:
           - ct
+        validation:
+          openAPIV3Schema:
+            type: object
+            properties:
+              spec:
+                type: object
+                properties:
+                  cronSpec:
+                    type: string
+                  image:
+                    type: string
+                  replicas:
+                    type: integer
         additionalPrinterColumns:
         - name: Spec
           type: string
@@ -1116,6 +1145,26 @@ spec:
     - name: v1
       served: true
       storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                cronSpec:
+                  type: string
+                image:
+                  type: string
+                replicas:
+                  type: integer
+            status:
+              type: object
+              properties:
+                replicas:
+                  type: integer
+                labelSelector:
+                  type: string
       # subresources describes the subresources for custom resources.
       subresources:
         # status enables the status subresource.
@@ -1139,6 +1188,7 @@ spec:
 {{% /tab %}}
 {{% tab name="apiextensions.k8s.io/v1beta1" %}}
 ```yaml
+# Deprecated in v1.16 in favor of apiextensions.k8s.io/v1
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -1156,6 +1206,26 @@ spec:
     kind: CronTab
     shortNames:
     - ct
+  validation:
+    openAPIV3Schema:
+      type: object
+      properties:
+        spec:
+          type: object
+          properties:
+            cronSpec:
+              type: string
+            image:
+              type: string
+            replicas:
+              type: integer
+        status:
+          type: object
+          properties:
+            replicas:
+              type: integer
+            labelSelector:
+              type: string
   # subresources describes the subresources for custom resources.
   subresources:
     # status enables the status subresource.
@@ -1249,6 +1319,19 @@ spec:
     - name: v1
       served: true
       storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                cronSpec:
+                  type: string
+                image:
+                  type: string
+                replicas:
+                  type: integer
   scope: Namespaced
   names:
     plural: crontabs
@@ -1263,6 +1346,7 @@ spec:
 {{% /tab %}}
 {{% tab name="apiextensions.k8s.io/v1beta1" %}}
 ```yaml
+# Deprecated in v1.16 in favor of apiextensions.k8s.io/v1
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -1273,6 +1357,19 @@ spec:
     - name: v1
       served: true
       storage: true
+  validation:
+    openAPIV3Schema:
+      type: object
+      properties:
+        spec:
+          type: object
+          properties:
+            cronSpec:
+              type: string
+            image:
+              type: string
+            replicas:
+              type: integer
   scope: Namespaced
   names:
     plural: crontabs


### PR DESCRIPTION
Updates to https://github.com/kubernetes/website/pull/15982

* Adds schema to v1 versions
* Changes JSONPath -> jsonPath
* Adds conversionReviewVersions
* Nests webhook.clientConfig
* Adds deprecation notice to v1beta1 examples
* Update conversion webhook docs to point to more recent examples
* Add webhook request/response with detailed ConversionReview docs
* Update openapi publishing feature stability